### PR TITLE
Corrected Draft a Release Button

### DIFF
--- a/content/github/administering-a-repository/managing-releases-in-a-repository.md
+++ b/content/github/administering-a-repository/managing-releases-in-a-repository.md
@@ -38,8 +38,8 @@ You can choose whether {% data variables.large_files.product_name_long %} ({% da
 
 {% data reusables.repositories.navigate-to-repo %}
 {% data reusables.repositories.releases %}
-3. Click **Draft a new release**.
-   ![Releases draft button](/assets/images/help/releases/draft_release_button.png)
+3. Click **Create a new release**.
+   ![Releases create button](/assets/images/help/releases/create_release_button.png)
 4. Type a version number for your release. Versions are based on [Git tags](https://git-scm.com/book/en/Git-Basics-Tagging). We recommend naming tags that fit within [semantic versioning](http://semver.org/).
    ![Releases tagged version](/assets/images/help/releases/releases-tag-version.png)
 5. Use the drop-down menu to select the branch that contains the project you want to release.


### PR DESCRIPTION
Changed "Draft a new release" to Create a new release, including bitmap

### Why:
When reading the online docs for GHE Server 2.21, I noticed what we have installed for 2.21 shows a different button and text for creating a new release. See #2010

### What's being changed:

Changed "Draft a new release" to Create a new release, including bitmap

Image and text for Create a new release.

### Check off the following:
- [x] All of the tests are passing.
- [ ] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
